### PR TITLE
Feat/implement/auth/register endpoint in auth core

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@types/jest": "^30.0.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "^24.0.3",
+    "@types/supertest": "^6.0.3",
     "execa": "^9.6.0",
     "jest": "^30.0.1",
     "prisma": "^6.10.1",
@@ -34,6 +35,8 @@
     "bcrypt": "^6.0.0",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "joi": "^17.13.3",
+    "supertest": "^7.1.1",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
   "packageManager": "pnpm@10.11.0",
   "devDependencies": {
     "@prisma/client": "^6.10.1",
+    "@types/bcrypt": "^5.0.2",
     "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",
+    "@types/mocha": "^10.0.10",
     "@types/node": "^24.0.3",
     "execa": "^9.6.0",
     "jest": "^30.0.1",
@@ -29,6 +31,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
+    "bcrypt": "^6.0.0",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "ts-node": "^10.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      bcrypt:
+        specifier: ^6.0.0
+        version: 6.0.0
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
@@ -24,12 +27,18 @@ importers:
       '@prisma/client':
         specifier: ^6.10.1
         version: 6.10.1(prisma@6.10.1(typescript@5.4.5))(typescript@5.4.5)
+      '@types/bcrypt':
+        specifier: ^5.0.2
+        version: 5.0.2
       '@types/express':
         specifier: ^5.0.3
         version: 5.0.3
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
+      '@types/mocha':
+        specifier: ^10.0.10
+        version: 10.0.10
       '@types/node':
         specifier: ^24.0.3
         version: 24.0.3
@@ -434,6 +443,9 @@ packages:
   '@types/babel__traverse@7.20.7':
     resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
 
+  '@types/bcrypt@5.0.2':
+    resolution: {integrity: sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==}
+
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
@@ -463,6 +475,9 @@ packages:
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
+  '@types/mocha@10.0.10':
+    resolution: {integrity: sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==}
 
   '@types/node@24.0.3':
     resolution: {integrity: sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==}
@@ -677,6 +692,10 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  bcrypt@6.0.0:
+    resolution: {integrity: sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==}
+    engines: {node: '>= 18'}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -1443,8 +1462,16 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  node-addon-api@8.4.0:
+    resolution: {integrity: sha512-D9DI/gXHvVmjHS08SVch0Em8G5S1P+QWtU31appcKT/8wFSPRcdHadIFSAntdMMVM5zz+/DL+bL/gz3UDppqtg==}
+    engines: {node: ^18 || ^20 || >= 21}
+
   node-cleanup@2.1.2:
     resolution: {integrity: sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -2534,6 +2561,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.27.6
 
+  '@types/bcrypt@5.0.2':
+    dependencies:
+      '@types/node': 24.0.3
+
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
@@ -2574,6 +2605,8 @@ snapshots:
       pretty-format: 30.0.2
 
   '@types/mime@1.3.5': {}
+
+  '@types/mocha@10.0.10': {}
 
   '@types/node@24.0.3':
     dependencies:
@@ -2766,6 +2799,11 @@ snapshots:
       babel-preset-current-node-syntax: 1.1.0(@babel/core@7.27.4)
 
   balanced-match@1.0.2: {}
+
+  bcrypt@6.0.0:
+    dependencies:
+      node-addon-api: 8.4.0
+      node-gyp-build: 4.8.4
 
   binary-extensions@2.3.0: {}
 
@@ -3700,7 +3738,11 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  node-addon-api@8.4.0: {}
+
   node-cleanup@2.1.2: {}
+
+  node-gyp-build@4.8.4: {}
 
   node-int64@0.4.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.1.0
+      joi:
+        specifier: ^17.13.3
+        version: 17.13.3
+      supertest:
+        specifier: ^7.1.1
+        version: 7.1.1
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@24.0.3)(typescript@5.4.5)
@@ -42,6 +48,9 @@ importers:
       '@types/node':
         specifier: ^24.0.3
         version: 24.0.3
+      '@types/supertest':
+        specifier: ^6.0.3
+        version: 6.0.3
       execa:
         specifier: ^9.6.0
         version: 9.6.0
@@ -244,6 +253,12 @@ packages:
   '@emnapi/wasi-threads@1.0.2':
     resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
 
+  '@hapi/hoek@9.3.0':
+    resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
+
+  '@hapi/topo@5.1.0':
+    resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -362,6 +377,13 @@ packages:
   '@napi-rs/wasm-runtime@0.2.11':
     resolution: {integrity: sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==}
 
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@paralleldrive/cuid2@2.2.2':
+    resolution: {integrity: sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -402,6 +424,15 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sideway/address@4.1.5':
+    resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
+
+  '@sideway/formula@3.0.1':
+    resolution: {integrity: sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==}
+
+  '@sideway/pinpoint@2.0.0':
+    resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
 
   '@sinclair/typebox@0.34.35':
     resolution: {integrity: sha512-C6ypdODf2VZkgRT6sFM8E1F8vR+HcffniX0Kp8MsU8PIfrlXbNCBz0jzj17GjdmjTx1OtZzdH8+iALL21UjF5A==}
@@ -452,6 +483,9 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/cookiejar@2.1.5':
+    resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
+
   '@types/express-serve-static-core@5.0.6':
     resolution: {integrity: sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==}
 
@@ -472,6 +506,9 @@ packages:
 
   '@types/jest@30.0.0':
     resolution: {integrity: sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==}
+
+  '@types/methods@1.1.4':
+    resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
@@ -502,6 +539,12 @@ packages:
 
   '@types/strip-json-comments@0.0.30':
     resolution: {integrity: sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==}
+
+  '@types/superagent@8.1.9':
+    resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
+
+  '@types/supertest@6.0.3':
+    resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -662,8 +705,14 @@ packages:
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   babel-jest@30.0.2:
     resolution: {integrity: sha512-A5kqR1/EUTidM2YC2YMEUDP2+19ppgOwK0IAd9Swc3q2KqFb5f9PtRUXVeZcngu0z5mDMyZ9zH2huJZSOMLiTQ==}
@@ -798,6 +847,13 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  component-emitter@1.3.1:
+    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -819,6 +875,9 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookiejar@2.1.4:
+    resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
@@ -851,6 +910,10 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -858,6 +921,9 @@ packages:
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
+
+  dezalgo@1.0.4:
+    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -920,6 +986,10 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -970,6 +1040,9 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
@@ -995,6 +1068,14 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  form-data@4.0.3:
+    resolution: {integrity: sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==}
+    engines: {node: '>= 6'}
+
+  formidable@3.5.4:
+    resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
+    engines: {node: '>=14.0.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -1079,6 +1160,10 @@ packages:
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
@@ -1337,6 +1422,9 @@ packages:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
 
+  joi@17.13.3:
+    resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1408,17 +1496,34 @@ packages:
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
 
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   mime-types@3.0.1:
     resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
+
+  mime@2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
 
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -1812,6 +1917,14 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  superagent@10.2.1:
+    resolution: {integrity: sha512-O+PCv11lgTNJUzy49teNAWLjBZfc+A1enOwTpLlH6/rsvKcTwcdTT8m9azGkVqM7HBl5jpyZ7KTPhHweokBcdg==}
+    engines: {node: '>=14.18.0'}
+
+  supertest@7.1.1:
+    resolution: {integrity: sha512-aI59HBTlG9e2wTjxGJV+DygfNLgnWbGdZxiA/sgrnNNikIW8lbDvCtF6RnhZoJ82nU7qv7ZLjrvWqCEm52fAmw==}
+    engines: {node: '>=14.18.0'}
 
   supports-color@2.0.0:
     resolution: {integrity: sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==}
@@ -2251,6 +2364,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@hapi/hoek@9.3.0': {}
+
+  '@hapi/topo@5.1.0':
+    dependencies:
+      '@hapi/hoek': 9.3.0
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -2478,6 +2597,12 @@ snapshots:
       '@tybys/wasm-util': 0.9.0
     optional: true
 
+  '@noble/hashes@1.8.0': {}
+
+  '@paralleldrive/cuid2@2.2.2':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -2514,6 +2639,14 @@ snapshots:
       '@prisma/debug': 6.10.1
 
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@sideway/address@4.1.5':
+    dependencies:
+      '@hapi/hoek': 9.3.0
+
+  '@sideway/formula@3.0.1': {}
+
+  '@sideway/pinpoint@2.0.0': {}
 
   '@sinclair/typebox@0.34.35': {}
 
@@ -2574,6 +2707,8 @@ snapshots:
     dependencies:
       '@types/node': 24.0.3
 
+  '@types/cookiejar@2.1.5': {}
+
   '@types/express-serve-static-core@5.0.6':
     dependencies:
       '@types/node': 24.0.3
@@ -2604,6 +2739,8 @@ snapshots:
       expect: 30.0.2
       pretty-format: 30.0.2
 
+  '@types/methods@1.1.4': {}
+
   '@types/mime@1.3.5': {}
 
   '@types/mocha@10.0.10': {}
@@ -2632,6 +2769,18 @@ snapshots:
   '@types/strip-bom@3.0.0': {}
 
   '@types/strip-json-comments@0.0.30': {}
+
+  '@types/superagent@8.1.9':
+    dependencies:
+      '@types/cookiejar': 2.1.5
+      '@types/methods': 1.1.4
+      '@types/node': 24.0.3
+      form-data: 4.0.3
+
+  '@types/supertest@6.0.3':
+    dependencies:
+      '@types/methods': 1.1.4
+      '@types/superagent': 8.1.9
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -2742,7 +2891,11 @@ snapshots:
     dependencies:
       sprintf-js: 1.0.3
 
+  asap@2.0.6: {}
+
   async@3.2.6: {}
+
+  asynckit@0.4.0: {}
 
   babel-jest@30.0.2(@babel/core@7.27.4):
     dependencies:
@@ -2918,6 +3071,12 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  component-emitter@1.3.1: {}
+
   concat-map@0.0.1: {}
 
   content-disposition@1.0.0:
@@ -2931,6 +3090,8 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookiejar@2.1.4: {}
 
   create-require@1.1.1: {}
 
@@ -2954,9 +3115,16 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  delayed-stream@1.0.0: {}
+
   depd@2.0.0: {}
 
   detect-newline@3.1.0: {}
+
+  dezalgo@1.0.4:
+    dependencies:
+      asap: 2.0.6
+      wrappy: 1.0.2
 
   diff@4.0.2: {}
 
@@ -3003,6 +3171,13 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   escalade@3.2.0: {}
 
@@ -3098,6 +3273,8 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
+  fast-safe-stringify@2.1.1: {}
+
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
@@ -3134,6 +3311,20 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  form-data@4.0.3:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
+  formidable@3.5.4:
+    dependencies:
+      '@paralleldrive/cuid2': 2.2.2
+      dezalgo: 1.0.4
+      once: 1.4.0
 
   forwarded@0.2.0: {}
 
@@ -3214,6 +3405,10 @@ snapshots:
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.2:
     dependencies:
@@ -3645,6 +3840,14 @@ snapshots:
 
   jiti@2.4.2: {}
 
+  joi@17.13.3:
+    dependencies:
+      '@hapi/hoek': 9.3.0
+      '@hapi/topo': 5.1.0
+      '@sideway/address': 4.1.5
+      '@sideway/formula': 3.0.1
+      '@sideway/pinpoint': 2.0.0
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.1:
@@ -3699,16 +3902,26 @@ snapshots:
 
   merge-stream@2.0.0: {}
 
+  methods@1.1.2: {}
+
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.1:
     dependencies:
       mime-db: 1.54.0
+
+  mime@2.6.0: {}
 
   mimic-fn@2.1.0: {}
 
@@ -4058,6 +4271,27 @@ snapshots:
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
+
+  superagent@10.2.1:
+    dependencies:
+      component-emitter: 1.3.1
+      cookiejar: 2.1.4
+      debug: 4.4.1
+      fast-safe-stringify: 2.1.1
+      form-data: 4.0.3
+      formidable: 3.5.4
+      methods: 1.1.2
+      mime: 2.6.0
+      qs: 6.14.0
+    transitivePeerDependencies:
+      - supports-color
+
+  supertest@7.1.1:
+    dependencies:
+      methods: 1.1.2
+      superagent: 10.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   supports-color@2.0.0: {}
 

--- a/prisma/migrations/20250625140310_fix_user_email_relation/migration.sql
+++ b/prisma/migrations/20250625140310_fix_user_email_relation/migration.sql
@@ -6,7 +6,7 @@ CREATE TABLE "Email" (
     "id" TEXT NOT NULL,
     "userId" TEXT NOT NULL,
     "email" TEXT NOT NULL,
-    "isPrimary" BOOLEAN NOT NULL,
+    "isPrimary" BOOLEAN NOT NULL DEFAULT false,
     "isVerified" BOOLEAN NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
@@ -20,7 +20,7 @@ CREATE TABLE "User" (
     "name" TEXT NOT NULL,
     "password" TEXT NOT NULL,
     "plan" "PlanType" NOT NULL DEFAULT 'FREE',
-    "profile" TEXT NOT NULL,
+    "profileImage" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
 
@@ -34,7 +34,7 @@ CREATE UNIQUE INDEX "Email_userId_key" ON "Email"("userId");
 CREATE UNIQUE INDEX "Email_email_key" ON "Email"("email");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "User_profile_key" ON "User"("profile");
+CREATE UNIQUE INDEX "User_profileImage_key" ON "User"("profileImage");
 
 -- AddForeignKey
-ALTER TABLE "Email" ADD CONSTRAINT "Email_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Email" ADD CONSTRAINT "Email_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250626133642_fix_user_email_relation/migration.sql
+++ b/prisma/migrations/20250626133642_fix_user_email_relation/migration.sql
@@ -1,5 +1,0 @@
--- DropIndex
-DROP INDEX "User_profileImage_key";
-
--- AlterTable
-ALTER TABLE "User" ALTER COLUMN "profileImage" DROP NOT NULL;

--- a/prisma/migrations/20250626133642_fix_user_email_relation/migration.sql
+++ b/prisma/migrations/20250626133642_fix_user_email_relation/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "User_profileImage_key";
+
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "profileImage" DROP NOT NULL;

--- a/prisma/migrations/20250701094608_init/migration.sql
+++ b/prisma/migrations/20250701094608_init/migration.sql
@@ -20,7 +20,7 @@ CREATE TABLE "User" (
     "name" TEXT NOT NULL,
     "password" TEXT NOT NULL,
     "plan" "PlanType" NOT NULL DEFAULT 'FREE',
-    "profileImage" TEXT NOT NULL,
+    "profileImage" TEXT,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
 
@@ -32,9 +32,6 @@ CREATE UNIQUE INDEX "Email_userId_key" ON "Email"("userId");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "Email_email_key" ON "Email"("email");
-
--- CreateIndex
-CREATE UNIQUE INDEX "User_profileImage_key" ON "User"("profileImage");
 
 -- AddForeignKey
 ALTER TABLE "Email" ADD CONSTRAINT "Email_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,9 +27,8 @@ model Email {
   isPrimary  Boolean @default(false)
   isVerified Boolean
 
-  createdAt              DateTime                @default(now())
-  updatedAt              DateTime                @updatedAt
-  EmailVerificationToken EmailVerificationToken?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 model User {
@@ -41,13 +40,4 @@ model User {
   profileImage String?
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
-}
-
-model EmailVerificationToken {
-  id        String   @id @default(uuid())
-  tokenHash String // Hashed token
-  emailId   String   @unique
-  email     Email    @relation(fields: [emailId], references: [id], onDelete: Cascade)
-  expiresAt DateTime
-  createdAt DateTime @default(now())
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,23 +20,34 @@ enum PlanType {
 }
 
 model Email {
-  id         String   @id @default(uuid())
-  userId     String   @unique
-  user       User     @relation(fields: [userId], references: [id])
-  email      String   @unique
-  isPrimary  Boolean
+  id         String  @id @default(uuid())
+  userId     String  @unique
+  user       User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  email      String  @unique
+  isPrimary  Boolean @default(false)
   isVerified Boolean
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
+
+  createdAt              DateTime                @default(now())
+  updatedAt              DateTime                @updatedAt
+  EmailVerificationToken EmailVerificationToken?
 }
 
 model User {
+  id           String   @id @default(uuid())
+  emails       Email[] // One-to-many
+  name         String
+  password     String
+  plan         PlanType @default(FREE)
+  profileImage String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+}
+
+model EmailVerificationToken {
   id        String   @id @default(uuid())
-  emails    Email[] // One-to-many
-  name      String
-  password  String
-  plan      PlanType @default(FREE)
-  profile   String   @unique
+  tokenHash String // Hashed token
+  emailId   String   @unique
+  email     Email    @relation(fields: [emailId], references: [id], onDelete: Cascade)
+  expiresAt DateTime
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
 }

--- a/src/Middlewares/validate.ts
+++ b/src/Middlewares/validate.ts
@@ -1,0 +1,18 @@
+import { Request, Response, NextFunction } from "express";
+import Joi from "joi";
+
+export const validate =
+  (schema: Joi.ObjectSchema) =>
+  (req: Request, res: Response, next: NextFunction): void => {
+    const { error } = schema.validate(req.body);
+
+    if (error) {
+      res.status(400).json({
+        error: "Validation error",
+        details: error.details.map((d) => d.message),
+      });
+
+      return;
+    }
+    next();
+  };

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,7 +24,9 @@ class App {
       res.status(404).json({ message: "Route not found" });
     });
   };
-
+  public getInstance = (): Application => {
+    return this.express;
+  };
   public startServer = () => {
     this.express.listen(this.PORT, () => {
       console.log(`🚀 Server running at http://localhost:${this.PORT}`);

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -12,9 +12,12 @@ class AuthController {
       const { email, name, password } = req.body;
 
       const userData = await this.AuthService.register(name, email, password);
-
       if (!userData) {
         res.status(400).json({ message: "User registration failed" });
+        return;
+      }
+      if ("error" in userData) {
+        res.status(userData.status).json({ message: userData.error });
         return;
       }
       res.status(201).json(userData);

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -7,15 +7,17 @@ class AuthController {
   constructor(authService?: AuthService) {
     this.AuthService = authService ?? new AuthService();
   }
-  public register = async (req: Request, res: Response) => {
+  public register = async (req: Request, res: Response): Promise<void> => {
     try {
       const { email, name, password } = req.body;
-      const userData = await this.AuthService.register(email, name, password);
+
+      const userData = await this.AuthService.register(name, email, password);
 
       if (!userData) {
-        return res.status(400).json({ message: "User registration failed" });
+        res.status(400).json({ message: "User registration failed" });
+        return;
       }
-      return res.status(201).json(userData);
+      res.status(201).json(userData);
     } catch (error: any) {
       res.status(500).json(error.message);
     }

--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from "express";
+import { AuthService } from "../services/auth.service";
+
+class AuthController {
+  private AuthService;
+
+  constructor(authService?: AuthService) {
+    this.AuthService = authService ?? new AuthService();
+  }
+  public register = async (req: Request, res: Response) => {
+    try {
+      const { email, name, password } = req.body;
+      const userData = await this.AuthService.register(email, name, password);
+
+      if (!userData) {
+        return res.status(400).json({ message: "User registration failed" });
+      }
+      return res.status(201).json(userData);
+    } catch (error: any) {
+      res.status(500).json(error.message);
+    }
+  };
+}
+
+export default AuthController;

--- a/src/repositories/auth.repository.ts
+++ b/src/repositories/auth.repository.ts
@@ -1,5 +1,5 @@
 import { Email, PrismaClient, User } from "@prisma/client";
-type EmailWithUser = Email & { user: Pick<User, "id" | "name" | "password"> };
+type EmailWithUser = Email & { user: Pick<User, "id" | "name"> };
 
 export class AuthRepository {
   private prisma;
@@ -15,7 +15,6 @@ export class AuthRepository {
           select: {
             name: true,
             id: true,
-            password: true,
           },
         },
       },

--- a/src/repositories/auth.repository.ts
+++ b/src/repositories/auth.repository.ts
@@ -1,0 +1,49 @@
+import { Email, PrismaClient, User } from "@prisma/client";
+type EmailWithUser = Email & { user: Pick<User, "id" | "name" | "password"> };
+
+export class AuthRepository {
+  private prisma;
+  constructor(prisma?: PrismaClient) {
+    this.prisma = prisma ?? new PrismaClient(); // fallback to real if none provided
+  }
+
+  public findByEmail = async (email: string): Promise<EmailWithUser | null> => {
+    return await this.prisma.email.findUnique({
+      where: { email },
+      include: {
+        user: {
+          select: {
+            name: true,
+            id: true,
+            password: true,
+          },
+        },
+      },
+    });
+  };
+  public createUser = (
+    email: string,
+    name: string,
+    password: string,
+    profileImage?: string
+  ): Promise<User | null> => {
+    return this.prisma.user.create({
+      data: {
+        profileImage,
+        name,
+        password,
+        emails: {
+          create: {
+            email,
+            isPrimary: true,
+            isVerified: false,
+          },
+        },
+      },
+
+      include: {
+        emails: true, // optional: if you want to return created email(s)
+      },
+    });
+  };
+}

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -1,7 +1,15 @@
 import { Router } from "express";
+import { validate } from "../Middlewares/validate";
+import { AuthValidation } from "../validations/auth.validation";
+import AuthController from "../controllers/auth.controller";
 
+const authController = new AuthController();
 const AuthRouter = Router();
 
-AuthRouter.get("/", () => {});
+AuthRouter.post(
+  "/register",
+  validate(AuthValidation.register),
+  authController.register
+);
 
 export default AuthRouter;

--- a/src/routes/auth.routes.ts
+++ b/src/routes/auth.routes.ts
@@ -1,0 +1,7 @@
+import { Router } from "express";
+
+const AuthRouter = Router();
+
+AuthRouter.get("/", () => {});
+
+export default AuthRouter;

--- a/src/routes/index.routes.ts
+++ b/src/routes/index.routes.ts
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import healthRouter from "./health.route";
+import AuthRouter from "./auth.routes";
 
 const routes = Router();
 
 routes.use("/health", healthRouter);
+routes.use("/auth", AuthRouter);
 
 export default routes;

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,0 +1,31 @@
+import { PrismaClient } from "@prisma/client";
+import { AuthRepository } from "../repositories/auth.repository";
+
+export class AuthService {
+  private readonly AuthRepo: AuthRepository;
+  constructor(authRepo?: AuthRepository) {
+    this.AuthRepo = authRepo ?? new AuthRepository();
+  }
+
+  public register = async (name: string, email: string, password: string) => {
+    try {
+      const existing: any = await this.AuthRepo.findByEmail(email);
+      if (existing) {
+        const primaryEmail = existing.emails?.find((e: any) => e.isPrimary);
+        const isVerified = primaryEmail?.isVerified ?? false;
+
+        if (!isVerified) {
+          throw new Error("User already exists but not verified");
+        }
+        throw new Error("User already exists");
+      }
+      const userData = await this.AuthRepo.createUser(email, name, password);
+      if (userData) {
+        // add email logic here in future
+      }
+      return userData;
+    } catch (error: any) {
+      throw new Error(error.message || "Internal server error");
+    }
+  };
+}

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -17,14 +17,17 @@ export class AuthService {
   ) => {
     try {
       const existing: any = await this.AuthRepo.findByEmail(email);
+
       if (existing) {
-        const primaryEmail = existing.emails?.find((e: any) => e.isPrimary);
-        const isVerified = primaryEmail?.isVerified ?? false;
+        const isVerified = existing.isVerified;
 
         if (!isVerified) {
-          throw new Error("User already exists but not verified");
+          return {
+            error: "User already exists but not verified",
+            status: 409,
+          };
         }
-        throw new Error("User already exists");
+        return { error: "User already exists", status: 409 };
       }
       const hashPassword = await this.Hasher.Password(rawPassword);
       const userData = await this.AuthRepo.createUser(
@@ -32,12 +35,10 @@ export class AuthService {
         name,
         hashPassword
       );
-      if (userData) {
-        // add email logic here in future
-      }
       if (!userData) {
-        throw new Error("User registration failed");
+        return { error: "User registration failed", status: 422 };
       }
+      // add email logic here in future
 
       const { password, ...safeUser } = userData;
 

--- a/src/utils/hash.util.ts
+++ b/src/utils/hash.util.ts
@@ -1,0 +1,31 @@
+import bcrypt from "bcrypt";
+
+export class Hasher {
+  private bcrypt;
+  private saltRounds: number;
+  constructor() {
+    this.bcrypt = bcrypt;
+    this.saltRounds = 12;
+  }
+
+  public Password = async (password: string): Promise<string> => {
+    try {
+      return await this.bcrypt.hash(password, this.saltRounds);
+    } catch (error) {
+      console.error("❌ Error while hashing password:", error);
+      throw new Error("Failed to hash password");
+    }
+  };
+
+  public comparePassword = async (
+    password: string,
+    hash: string
+  ): Promise<boolean> => {
+    try {
+      return await this.bcrypt.compare(password, hash);
+    } catch (error) {
+      console.error("❌ Error while comparing password:", error);
+      throw new Error("Failed to compare password");
+    }
+  };
+}

--- a/src/validations/auth.validation.ts
+++ b/src/validations/auth.validation.ts
@@ -1,0 +1,9 @@
+import Joi from "joi";
+
+export class AuthValidation {
+  static register = Joi.object({
+    email: Joi.string().email().required(),
+    password: Joi.string().min(8).required(),
+    name: Joi.string().min(5).required(),
+  });
+}

--- a/tests/integration/auth.register.test.ts
+++ b/tests/integration/auth.register.test.ts
@@ -1,0 +1,142 @@
+import request from "supertest";
+import App from "../../src/app";
+const app = new App().getInstance();
+
+describe("POST /api/auth/register", () => {
+  const email = `${Date.now()}@example.com`;
+  it("Registers a new user successfully with valid input", async () => {
+    const body = {
+      name: "Harsh",
+      email,
+      password: "StrongPass123",
+    };
+    const res = await request(app).post("/api/auth/register").send(body);
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body).not.toBeNull();
+    expect(res.body).toHaveProperty("name", body.name);
+    expect(res.body.emails[0]).toHaveProperty("email", body.email);
+  });
+  it("Returns 500 if email is already taken", async () => {
+    const body = {
+      name: "Harsh",
+      email,
+      password: "StrongPass123",
+    };
+    const res = await request(app).post("/api/auth/register").send(body);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error: "Validation error",
+      details: ['"email" is required'],
+    });
+  });
+  it("Returns 400 if email is missing", async () => {
+    const body = {
+      name: "Harsh",
+      password: "StrongPass123",
+    };
+    const res = await request(app).post("/api/auth/register").send(body);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error: "Validation error",
+      details: ['"email" is required'],
+    });
+  });
+  it("Returns 400 if name is missing", async () => {
+    const body = {
+      password: "StrongPass123",
+      email: `${Date.now()}@example.com`,
+    };
+    const res = await request(app).post("/api/auth/register").send(body);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error: "Validation error",
+      details: ['"name" is required'],
+    });
+  });
+
+  it("Returns 400 if password is missing", async () => {
+    const body = {
+      name: "Harsh",
+      email: `${Date.now()}@example.com`,
+    };
+    const res = await request(app).post("/api/auth/register").send(body);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error: "Validation error",
+      details: ['"password" is required'],
+    });
+  });
+  it("Returns 400 if body is empty", async () => {
+    const body = {};
+    const res = await request(app).post("/api/auth/register").send(body);
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("Returns 400 if extra unexpected fields are sent", async () => {
+    const body = {
+      name: "Harsh",
+      email: `${Date.now()}@example.com`,
+      password: "StrongPass123",
+      role: "admin",
+    };
+    const res = await request(app).post("/api/auth/register").send(body);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toStrictEqual({
+      error: "Validation error",
+      details: ['"role" is not allowed'],
+    });
+  });
+
+  it("Returns 400 if password is too short", async () => {
+    const body = {
+      name: "Harsh",
+      email: `${Date.now()}@example.com`,
+      password: "S123",
+    };
+    const res = await request(app).post("/api/auth/register").send(body);
+
+    expect(res.statusCode).toBe(400);
+
+    expect(res.body).toStrictEqual({
+      error: "Validation error",
+      details: ['"password" length must be at least 8 characters long'],
+    });
+  });
+  it("Returns 400 if name is too short", async () => {
+    const body = {
+      name: "Ha",
+      email: `${Date.now()}@example.com`,
+      password: "Strong123",
+    };
+    const res = await request(app).post("/api/auth/register").send(body);
+
+    expect(res.statusCode).toBe(400);
+
+    expect(res.body).toStrictEqual({
+      error: "Validation error",
+      details: ['"name" length must be at least 5 characters long'],
+    });
+  });
+
+  it("Returns 400 if email format is invalid", async () => {
+    const body = {
+      name: "Harsh",
+      email: `${Date.now()}@email`,
+      password: "Strong123",
+    };
+    const res = await request(app).post("/api/auth/register").send(body);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toStrictEqual({
+      error: "Validation error",
+      details: ['"email" must be a valid email'],
+    });
+  });
+});

--- a/tests/integration/auth.register.test.ts
+++ b/tests/integration/auth.register.test.ts
@@ -17,7 +17,7 @@ describe("POST /api/auth/register", () => {
     expect(res.body).toHaveProperty("name", body.name);
     expect(res.body.emails[0]).toHaveProperty("email", body.email);
   });
-  it("Returns 500 if email is already taken", async () => {
+  it("Returns 409 if email is already taken but not verified", async () => {
     const body = {
       name: "Harsh",
       email,
@@ -25,12 +25,26 @@ describe("POST /api/auth/register", () => {
     };
     const res = await request(app).post("/api/auth/register").send(body);
 
-    expect(res.statusCode).toBe(400);
+    expect(res.statusCode).toBe(409);
     expect(res.body).toEqual({
-      error: "Validation error",
-      details: ['"email" is required'],
+      message: "User already exists but not verified",
     });
   });
+
+  it("Returns 409 if email is already taken  verified", async () => {
+    const body = {
+      name: "Harsh",
+      email: "test@example.com",
+      password: "StrongPass123",
+    };
+    const res = await request(app).post("/api/auth/register").send(body);
+
+    expect(res.statusCode).toBe(409);
+    expect(res.body).toEqual({
+      message: "User already exists",
+    });
+  });
+
   it("Returns 400 if email is missing", async () => {
     const body = {
       name: "Harsh",

--- a/tests/mocks/prisma.mock.ts
+++ b/tests/mocks/prisma.mock.ts
@@ -1,5 +1,5 @@
 // 👇 Define the mock object
-export const mockPrisma = {
+export const mockPrismaObject = {
   user: {
     findUnique: jest.fn(),
     findFirst: jest.fn(),
@@ -11,17 +11,24 @@ export const mockPrisma = {
     count: jest.fn(),
     aggregate: jest.fn(),
   },
+  email: {
+    findUnique: jest.fn(),
+    findMany: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
   $connect: jest.fn(),
   $disconnect: jest.fn(),
   $on: jest.fn(),
 };
 
 jest.mock("@prisma/client", () => ({
-  PrismaClient: jest.fn(() => mockPrisma),
+  PrismaClient: jest.fn(() => mockPrismaObject),
 }));
 
 // 👇 Now you can safely import PrismaClient after mocking
 import { PrismaClient } from "@prisma/client";
 
 // 👇 Export instance that uses mockPrisma
-export const prisma = new PrismaClient();
+export const mockPrisma = new PrismaClient();

--- a/tests/setup/jest.config.integration.ts
+++ b/tests/setup/jest.config.integration.ts
@@ -3,13 +3,12 @@ import type { Config } from "jest";
 const config: Config = {
   preset: "ts-jest",
   testEnvironment: "node",
-  testMatch: ["**/tests/integration/**/*.test.ts"],
+  rootDir: "../..",
+  testMatch: ["<rootDir>/tests/integration/**/*.test.ts"],
   setupFiles: ["dotenv/config"], // loads .env.test
   modulePathIgnorePatterns: ["<rootDir>/dist/"],
-  globals: {
-    "ts-jest": {
-      isolatedModules: true,
-    },
+  transform: {
+    "^.+\\.ts$": ["ts-jest", {}], // moved ts-jest config here
   },
 };
 

--- a/tests/setup/jest.config.unit.ts
+++ b/tests/setup/jest.config.unit.ts
@@ -3,13 +3,11 @@ import type { Config } from "jest";
 const config: Config = {
   preset: "ts-jest",
   testEnvironment: "node",
-  testMatch: ["**/tests/unit/**/*.test.ts"],
-
+  rootDir: "../..",
+  testMatch: ["<rootDir>/tests/unit/**/*.test.ts"],
   modulePathIgnorePatterns: ["<rootDir>/dist/"],
-  globals: {
-    "ts-jest": {
-      isolatedModules: true,
-    },
+  transform: {
+    "^.+\\.ts$": ["ts-jest", {}], // moved ts-jest config here
   },
 };
 

--- a/tests/unit/controllers/auth.controller.test.ts
+++ b/tests/unit/controllers/auth.controller.test.ts
@@ -1,0 +1,63 @@
+import { Request } from "express";
+import AuthController from "../../../src/controllers/auth.controller";
+
+describe(" Auth Repository", () => {
+  const mockUserData = {
+    id: "user1",
+    name: "Harsh",
+    password: "secret",
+    profileImage: "img.png",
+    plan: "FREE", //  // assuming this is your enum value
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    emails: [
+      {
+        id: "email1",
+        email: "harsh@example.com",
+        isPrimary: true,
+        isVerified: true,
+        userId: "user1",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ],
+  };
+  const mockAuthService = {
+    register: jest.fn(),
+  };
+  const authController = new AuthController(mockAuthService as any);
+
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as any;
+
+  const req = {
+    body: {
+      email: "test@example.com",
+      name: "Test",
+      password: "password123",
+    },
+  } as Request;
+
+  it("should register a user and return 201 with user data when input is valid", async () => {
+    mockAuthService.register.mockResolvedValue(mockUserData);
+    await authController.register(req, res);
+    expect(res).not.toBeNull();
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(mockUserData);
+  });
+
+  it("should return 400 when user registration fails (e.g., userData is null)", async () => {
+    mockAuthService.register.mockResolvedValue(null);
+    await authController.register(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(mockUserData);
+  });
+
+  it("should return 500 when AuthService throws an unexpected error", async () => {
+    mockAuthService.register.mockRejectedValue(
+      new Error("Internal server error")
+    );
+    await authController.register(req, res);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith("Internal server error");
+  });
+});

--- a/tests/unit/controllers/auth.controller.test.ts
+++ b/tests/unit/controllers/auth.controller.test.ts
@@ -48,7 +48,9 @@ describe(" Auth Repository", () => {
   it("should return 400 when user registration fails (e.g., userData is null)", async () => {
     mockAuthService.register.mockResolvedValue(null);
     await authController.register(req, res);
+
     expect(res.status).toHaveBeenCalledWith(400);
+
     expect(res.json).toHaveBeenCalledWith(mockUserData);
   });
 

--- a/tests/unit/repositories/auth.repository.test.ts
+++ b/tests/unit/repositories/auth.repository.test.ts
@@ -1,0 +1,69 @@
+import { PlanType } from "@prisma/client";
+import { AuthRepository } from "../../../src/repositories/auth.repository";
+import { mockPrisma } from "../../../tests/mocks/prisma.mock";
+describe(" Auth Repository", () => {
+  const AuthRepo = new AuthRepository(mockPrisma);
+  const email = "test@example.com";
+
+  const mockUser = {
+    email: "test@example.com",
+    isPrimary: true,
+    user: {
+      name: "test",
+      password: "hashedpwd",
+      id: "der909ru804u0u8950",
+    },
+  };
+  const mockUserData = {
+    id: "user1",
+    name: "Harsh",
+    password: "secret",
+    profileImage: "img.png",
+    plan: PlanType.FREE, //  // assuming this is your enum value
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    emails: [
+      {
+        id: "email1",
+        email: "harsh@example.com",
+        isPrimary: true,
+        isVerified: false,
+        userId: "user1",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ],
+  };
+
+  it("should return null if email does not exist", async () => {
+    (mockPrisma.email.findUnique as jest.Mock).mockResolvedValue(null);
+    const user = await AuthRepo.findByEmail(email);
+    expect(user).toBeNull();
+  });
+
+  it("should return email with user if found by email ", async () => {
+    (mockPrisma.email.findUnique as jest.Mock).mockResolvedValue(mockUser);
+    const user = await AuthRepo.findByEmail(email);
+    expect(user).not.toBeNull();
+    expect(user).toBe(mockUser);
+  });
+  it("should returns user when email  exist  ", async () => {
+    (mockPrisma.email.findUnique as jest.Mock).mockResolvedValue(mockUser);
+    const user = await AuthRepo.findByEmail(email);
+    expect(user).not.toBeNull();
+    expect(user).toBe(mockUser);
+  });
+
+  it("should create a user with provided data &&  return the created user object on success  ", async () => {
+    jest.spyOn(mockPrisma.user, "create").mockResolvedValue(mockUserData);
+
+    const user = await AuthRepo.createUser(
+      mockUser.email,
+      mockUser.user.name,
+      mockUser.user.password,
+      "dd"
+    );
+    expect(user).not.toBeNull();
+    expect(user).toBe(mockUserData);
+  });
+});

--- a/tests/unit/services/auth.service.test.ts
+++ b/tests/unit/services/auth.service.test.ts
@@ -1,0 +1,109 @@
+import { PlanType } from "@prisma/client";
+import { AuthService } from "../../../src/services/auth.service";
+
+describe("Auth Service", () => {
+  const mockAuthRepo = {
+    findByEmail: jest.fn(),
+    createUser: jest.fn(),
+  };
+
+  const authService = new AuthService(mockAuthRepo as any);
+  const email = "test@emaple.com";
+  const password = "1235475";
+  const name = "test";
+
+  it("should register a new user when email is not taken", async () => {
+    const mockUserData = {
+      id: "user1",
+      name: "Harsh",
+      password: "secret",
+      profileImage: "img.png",
+      plan: PlanType.FREE, //  // assuming this is your enum value
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      emails: [
+        {
+          id: "email1",
+          email: "harsh@example.com",
+          isPrimary: true,
+          isVerified: true,
+          userId: "user1",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+    };
+
+    mockAuthRepo.createUser.mockResolvedValue(mockUserData);
+
+    const result = await authService.register(email, name, password);
+    expect(result).not.toBeNull();
+    expect(result).toEqual(mockUserData);
+  });
+  it("should throw an error when the email is already taken and verified", async () => {
+    const mockUserData = {
+      id: "user1",
+      name: "Harsh",
+      password: "secret",
+      profileImage: "img.png",
+      plan: PlanType.FREE, //  // assuming this is your enum value
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      emails: [
+        {
+          id: "email1",
+          email: "harsh@example.com",
+          isPrimary: true,
+          isVerified: true,
+          userId: "user1",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+    };
+    mockAuthRepo.findByEmail.mockResolvedValue(mockUserData);
+
+    await expect(authService.register(name, email, password)).rejects.toThrow(
+      "User already exists"
+    );
+  });
+  it("should throw an error when the email is already taken but not verified", async () => {
+    const mockUserData = {
+      id: "user1",
+      name: "Harsh",
+      password: "secret",
+      profileImage: "img.png",
+      plan: PlanType.FREE, //  // assuming this is your enum value
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      emails: [
+        {
+          id: "email1",
+          email: "harsh@example.com",
+          isPrimary: true,
+          isVerified: false,
+          userId: "user1",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+    };
+    mockAuthRepo.findByEmail.mockResolvedValue(mockUserData);
+
+    await expect(authService.register(name, email, password)).rejects.toThrow(
+      "User already exists but not verified"
+    );
+  });
+  it("should throw an internal server error if something unexpected occurs in repository", async () => {
+    const mockRepo = {
+      findByEmail: jest.fn().mockRejectedValue(new Error("DB crashed")),
+      createUser: jest.fn(),
+    };
+
+    const authService = new AuthService(mockRepo as any); // ✅ Inject mock
+
+    await expect(
+      authService.register("test@example.com", "Test", "secret123")
+    ).rejects.toThrow("DB crashed");
+  });
+});

--- a/tests/unit/services/auth.service.test.ts
+++ b/tests/unit/services/auth.service.test.ts
@@ -16,7 +16,6 @@ describe("Auth Service", () => {
     const mockUserData = {
       id: "user1",
       name: "Harsh",
-      password: "secret",
       profileImage: "img.png",
       plan: PlanType.FREE, //  // assuming this is your enum value
       createdAt: new Date(),
@@ -44,7 +43,6 @@ describe("Auth Service", () => {
     const mockUserData = {
       id: "user1",
       name: "Harsh",
-      password: "secret",
       profileImage: "img.png",
       plan: PlanType.FREE, //  // assuming this is your enum value
       createdAt: new Date(),
@@ -71,7 +69,6 @@ describe("Auth Service", () => {
     const mockUserData = {
       id: "user1",
       name: "Harsh",
-      password: "secret",
       profileImage: "img.png",
       plan: PlanType.FREE, //  // assuming this is your enum value
       createdAt: new Date(),

--- a/tests/unit/services/auth.service.test.ts
+++ b/tests/unit/services/auth.service.test.ts
@@ -61,9 +61,12 @@ describe("Auth Service", () => {
     };
     mockAuthRepo.findByEmail.mockResolvedValue(mockUserData);
 
-    await expect(authService.register(name, email, password)).rejects.toThrow(
-      "User already exists"
-    );
+    const result = await authService.register(name, email, password);
+
+    expect(result).toEqual({
+      error: "User already exists but not verified",
+      status: 409,
+    });
   });
   it("should throw an error when the email is already taken but not verified", async () => {
     const mockUserData = {
@@ -86,10 +89,12 @@ describe("Auth Service", () => {
       ],
     };
     mockAuthRepo.findByEmail.mockResolvedValue(mockUserData);
+    const result = await authService.register(name, email, password);
 
-    await expect(authService.register(name, email, password)).rejects.toThrow(
-      "User already exists but not verified"
-    );
+    expect(result).toEqual({
+      error: "User already exists but not verified",
+      status: 409,
+    });
   });
   it("should throw an internal server error if something unexpected occurs in repository", async () => {
     const mockRepo = {

--- a/tests/unit/utils/hash.util.test.ts
+++ b/tests/unit/utils/hash.util.test.ts
@@ -1,0 +1,25 @@
+import { Hasher } from "../../../src/utils/hash.util";
+
+describe("Hasher Utility", () => {
+  const hasher = new Hasher();
+  const password = "securePassword123";
+  let hashedPassword: string;
+
+  it("should hash the password", async () => {
+    hashedPassword = await hasher.Password(password);
+    expect(typeof hashedPassword).toBe("string");
+    expect(hashedPassword).not.toBe(password);
+  });
+
+  it("should compare password correctly", async () => {
+    const isMatch = await hasher.comparePassword(password, hashedPassword);
+    expect(isMatch).toBe(true);
+  });
+  it("should return false for incorrect password", async () => {
+    const result = await hasher.comparePassword(
+      "wrongPassword",
+      hashedPassword
+    );
+    expect(result).toBe(false);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,13 +3,14 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "module": "commonjs",
+    "types": ["jest","node"],
     "target": "ES2020",
     "outDir": "./dist",
     "rootDir": ".",
     "strict": true,
     "skipLibCheck": true
   },
-  "exclude": [ "dist","tests"]
+  "exclude": [ "dist"]
 ,
-  "include": ["src"]
+  "include": ["src","tests","jest.config.*.ts"]
 }


### PR DESCRIPTION
## 📄 Feature Description

Implement the `POST /auth/register` endpoint to allow new user registration with email, name, and password in the `auth-core` service.

This feature handles input validation, secure password storage, duplicate user checks (both verified and unverified), and provides a clean response object without sensitive data. The implementation is fully tested through both unit and integration testing.

---

Several edge-case and setup issues were discovered during implementation of the now-closed issue [DesiLinkr/issue-center/issues/9] and have been fixed in this PR.

closes DesiLinkr/issue-center/issues/11

## 📋 Tasks

### ✅ Route Setup
- [x] Define Express route: `POST /auth/register`
- [x] Validate input using Joi and middleware

### ✅ Business Logic
- [x] Check if email already exists
- [x] Handle logic for unverified and verified users
- [x] Hash password securely using `bcrypt`
- [x] Store new user and primary email in the database
- [x] Return sanitized response (exclude password)

### ✅ Testing (Unit + Integration)

#### Unit Tests
- [x] Controller
- [x] Service
- [x] Repository
- [x] Utils (password hashing)

#### Integration Tests
- [x] Registers a new user successfully with valid input → `201 Created`
- [x] Returns `409` if email is already taken but not verified
- [x] Returns `409` if email is already taken and verified
- [x] Returns `400` if email is missing
- [x] Returns `400` if name is missing
- [x] Returns `400` if password is missing
- [x] Returns `400` if body is empty
- [x] Returns `400` if extra unexpected fields are sent
- [x] Returns `400` if password is too short
- [x] Returns `400` if name is too short
- [x] Returns `400` if email format is invalid

### ✅ Utilities
- [x] `hashPassword` and `comparePassword` helpers
- [x] Reusable `validate(schema)` middleware

---

## 🧾 Notes

- ✅ Email delivery logic will be added as a separate feature
- ✅ Password hashing follows best practices (`bcrypt` with salt)
- 📌 All password fields are excluded from the response
- 📌 Errors return appropriate status codes (`400`, `409`)
