### PR TITLE
# PR: Integrate Email gRPC RPCs in Auth-Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 /generated/prisma
 dist
 /generated/prisma
+/src/grpc/generated/

--- a/src/cache/emailVerification.cache.ts
+++ b/src/cache/emailVerification.cache.ts
@@ -2,11 +2,11 @@ import { AbstractTokenCache } from "./abstract.token.cache";
 
 export class EmailVerificationTokenCache extends AbstractTokenCache {
   protected prefix = "verify";
-  private readonly TTL_SECONDS = 600; // 10 mint
   public createToken = async (
     identifier: string,
-    token: string
+    token: string,
+    TTL_SECONDS: number
   ): Promise<void> => {
-    await this.setToken(identifier, token, this.TTL_SECONDS);
+    await this.setToken(identifier, token, TTL_SECONDS);
   };
 }

--- a/src/cache/forgotPassword.cache.ts
+++ b/src/cache/forgotPassword.cache.ts
@@ -5,8 +5,9 @@ export class ForgotPasswordTokenCache extends AbstractTokenCache {
   private readonly TTL_SECONDS = 900; // 15 mint
   public createToken = async (
     identifier: string,
-    token: string
+    token: string,
+    TTL_SECONDS: number
   ): Promise<void> => {
-    await this.setToken(identifier, token, this.TTL_SECONDS);
+    await this.setToken(identifier, token, TTL_SECONDS);
   };
 }

--- a/src/controllers/forgotPassword.controller.ts
+++ b/src/controllers/forgotPassword.controller.ts
@@ -24,6 +24,8 @@ class ForgotPasswordController {
       }
       res.status(200).json(result);
     } catch (error: any) {
+      console.log(error);
+
       res.status(500).json("Internal server error");
     }
   };

--- a/src/grpc/client.ts
+++ b/src/grpc/client.ts
@@ -2,8 +2,10 @@
 import { credentials } from "@grpc/grpc-js";
 import { SessionServiceClient } from "./generated/session";
 import { AccessServiceClient } from "./generated/access";
+import { EmailClient } from "./generated/email";
 
 const Acess_core = process.env.Acess_core_grpc_URL || "localhost:5052";
+const email_service = process.env.email_service || "localhost:4692";
 const sessionClient = new SessionServiceClient(
   Acess_core,
   credentials.createInsecure()
@@ -13,8 +15,13 @@ const accessClient = new AccessServiceClient(
   Acess_core,
   credentials.createInsecure()
 );
+const emailClient = new EmailClient(
+  email_service,
+  credentials.createInsecure()
+);
 
 export const grpcClient = {
   session: sessionClient,
   accessVerifier: accessClient,
+  email: emailClient,
 };

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,11 +1,16 @@
-import { PrismaClient } from "@prisma/client";
 import { AuthRepository } from "../repositories/auth.repository";
 import { Hasher } from "../utils/hash.util";
+import { sendVerificationEmail } from "../utils/grpc.util";
+import { EmailVerificationTokenCache } from "../cache/emailVerification.cache";
+import { VerificationEmailRequest } from "../grpc/generated/email";
 
 export class AuthService {
   private readonly AuthRepo: AuthRepository;
   private readonly Hasher: Hasher;
-  constructor(authRepo?: AuthRepository) {
+  private cache;
+  constructor(authRepo?: AuthRepository, cache?: EmailVerificationTokenCache) {
+    this.cache = cache ?? new EmailVerificationTokenCache();
+
     this.AuthRepo = authRepo ?? new AuthRepository();
     this.Hasher = new Hasher();
   }
@@ -38,12 +43,27 @@ export class AuthService {
       if (!userData) {
         return { error: "User registration failed", status: 422 };
       }
-      // add email logic here in future
+      const token = await this.Hasher.generateToken();
+      const expirytime = 600;
+      await this.cache.createToken(userData.id, token, expirytime);
 
+      const req: VerificationEmailRequest = {
+        to: email,
+        data: {
+          name,
+          expiry: Math.floor(expirytime / 60),
+          verifyUrl: `${process.env.url}:${process.env.PORT}/${token}`,
+          year: `${new Date().getFullYear()}`,
+        },
+        retry: 0,
+      };
+      await sendVerificationEmail(req);
       const { password, ...safeUser } = userData;
 
       return safeUser;
     } catch (error: any) {
+      console.log(error);
+
       throw new Error(error.message || "Internal server error");
     }
   };

--- a/src/services/forgotPassword.service.ts
+++ b/src/services/forgotPassword.service.ts
@@ -1,5 +1,7 @@
 import { ForgotPasswordTokenCache } from "../cache/forgotPassword.cache";
+import { ForgotPasswordRequest } from "../grpc/generated/email";
 import { AuthRepository } from "../repositories/auth.repository";
+import { sendforgotPassword } from "../utils/grpc.util";
 import { Hasher } from "../utils/hash.util";
 
 export class ForgotPasswordService {
@@ -28,14 +30,26 @@ export class ForgotPasswordService {
           status: 409,
         };
       }
+      const expirytime = 900;
 
-      await this.cache.createToken(userData.user.id, token);
+      await this.cache.createToken(userData.user.id, token, expirytime);
 
+      const req: ForgotPasswordRequest = {
+        to: email,
+        data: {
+          name: userData.user.name,
+          resetLink: `http://localhost:${process.env.PORT}/${token}`,
+          year: `${new Date().getFullYear()}`,
+          expiry: Math.floor(expirytime / 60),
+        },
+        retry: 0,
+      };
+
+      await sendforgotPassword(req);
       return {
         message:
           "If this email exists, password reset instructions have been sent.",
       };
-      // add email logic here in future
     } catch (error: any) {
       throw new Error(error.message || "Internal server error");
     }

--- a/src/utils/grpc.util.ts
+++ b/src/utils/grpc.util.ts
@@ -8,6 +8,17 @@ import {
   AccessVerifierResponse,
 } from "../grpc/generated/access";
 
+import {
+  AccessEmailRequest,
+  emailServiceResponse,
+  ForgotPasswordRequest,
+  VerificationEmailRequest,
+} from "../grpc/generated/email";
+import { error } from "console";
+import { response } from "express";
+import axios from "axios";
+import { Customformat } from "./timeformat";
+
 export function createSessionGrpc(
   request: CreateSessionRequest
 ): Promise<CreateSessionResponse> {
@@ -22,6 +33,19 @@ export function createSessionGrpc(
   });
 }
 
+export const sendVerificationEmail = (
+  request: VerificationEmailRequest
+): Promise<emailServiceResponse> => {
+  return new Promise((resolve, reject) => {
+    grpcClient.email.sendVerificationEmail(request, (error, response) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(response);
+      }
+    });
+  });
+};
 export const AccessVerifier = (
   request: AccessVerifierRequest
 ): Promise<AccessVerifierResponse> => {
@@ -34,4 +58,53 @@ export const AccessVerifier = (
       }
     });
   });
+};
+export const sendforgotPassword = (
+  request: ForgotPasswordRequest
+): Promise<emailServiceResponse> => {
+  return new Promise((resolve, reject) => {
+    grpcClient.email.sendforgotPassword(request, (error, response) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(response);
+      }
+    });
+  });
+};
+
+export const sendAcesssEmail = async (request: {
+  name: string;
+  to: string;
+  secureAccountUrl: string;
+  ipAddress: string;
+}): Promise<emailServiceResponse> => {
+  try {
+    // Fetch IP location using ipapi.co
+    const res = await axios.get(`https://ipapi.co/${request.ipAddress}/json/`);
+
+    const req: AccessEmailRequest = {
+      to: request.to,
+      data: {
+        location: `${res?.data?.city}, ${res?.data?.country_name}`,
+        name: request.name,
+        year: `${new Date().getFullYear()}`,
+        ipAddress: request.ipAddress,
+        secureAccountUrl: request.secureAccountUrl,
+        dateTime: `${Customformat(new Date())}`,
+      },
+      retry: 0,
+    };
+
+    // Wrap gRPC call in a Promise for await support
+    return await new Promise((resolve, reject) => {
+      grpcClient.email.sendAcesssEmail(req, (error, response) => {
+        if (error) reject(error);
+        else resolve(response);
+      });
+    });
+  } catch (err: any) {
+    console.error("Error in sendAcesssEmail:", err.message);
+    throw err;
+  }
 };

--- a/src/utils/timeformat.ts
+++ b/src/utils/timeformat.ts
@@ -1,0 +1,17 @@
+export const Customformat = (date: Date) => {
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+  const ampm = hours >= 12 ? "PM" : "AM";
+  const formattedHour = hours % 12 || 12;
+
+  const time =
+    minutes > 0
+      ? `${formattedHour}:${minutes.toString().padStart(2, "0")} ${ampm}`
+      : `${formattedHour} ${ampm}`;
+
+  const formattedDate = `${
+    date.getMonth() + 1
+  }/${date.getDate()}/${date.getFullYear()}`;
+
+  return `${time}, ${formattedDate}`;
+};


### PR DESCRIPTION


## 📌 Description
This PR integrates **email_service** RPCs into **auth-core** so that authentication workflows can trigger email actions via gRPC. The following RPCs are consumed:

- `sendVerificationEmail(VerificationEmailRequest)`  
- `sendForgotPassword(ForgotPasswordRequest)`

This allows **auth-core** to delegate email sending (verification & forgot password) to the centralized **email_service**, keeping authentication logic clean and reusing existing email infrastructure.

---

## 🧭 Changes Made
- Added gRPC client for **email_service** (`src/grpc/clients/email.client.ts`)
- Integrated `sendVerificationEmail()` in signup verification flow
- Integrated `sendForgotPassword()` in forgot-password flow
- Added error handling for failed gRPC calls

---

## ✅ Benefits
- Keeps **auth-core** focused on authentication logic
- Reuses robust email infrastructure (templates, retry, fail logs)
- Supports centralized email monitoring and future scaling
